### PR TITLE
fix: update bedrock_advanced.py to use HttpCallTemplate instead of de…

### DIFF
--- a/examples/bedrock_advanced.py
+++ b/examples/bedrock_advanced.py
@@ -76,26 +76,22 @@ async def main():
     
     # Create UTCP client directly
     print("\n📡 Creating UTCP client...")
-    config = UtcpClientConfig()
+    # Create UTCP client with call templates
+    print("📡 Creating UTCP client...")
+    config = UtcpClientConfig(
+        manual_call_templates=[
+            HttpCallTemplate(
+                name="openlibrary",
+                call_template_type="http",
+                url="https://openlibrary.org/static/openapi.json",
+                http_method="GET",
+                content_type="application/json"
+            )
+        ]
+    )
     client = await UtcpClient.create(config=config)
     
-    # Register providers using Provider objects
-    print("📡 Registering providers...")
-    
-    # Register OpenLibrary provider for demonstration
-    openlibrary_provider = HttpProvider(
-        name="openlibrary",
-        provider_type="http",
-        http_method="GET",
-        url="https://openlibrary.org/static/openapi.json",
-        content_type="application/json"
-    )
-    await client.register_tool_provider(openlibrary_provider)
-    
-    # Note: Only registering real APIs with proper OpenAPI specs
-    # HTTPBin doesn't provide OpenAPI spec, so we skip it
-    
-    print("✅ Providers registered successfully")
+    print("✅ Successfully created UTCP client with call templates")
     
     try:
         # Load tools


### PR DESCRIPTION
Deprecated HttpProvider

- Remove non-existent HttpProvider import that was causing ModuleNotFoundError
- Replace provider registration with HttpCallTemplate in UtcpClientConfig
- Update to use UTCP 1.0.0+ API pattern consistent with other examples
- Fixes runtime error when running bedrock_advanced.py example

Resolves issue where bedrock_advanced.py would fail with: ModuleNotFoundError: No module named 'utcp.shared'
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Replaced deprecated HttpProvider with HttpCallTemplate in bedrock_advanced.py to match UTCP 1.0.0+ and fix the runtime error. The example now creates the client with manual call templates and runs without ModuleNotFoundError.

- **Bug Fixes**
  - Removed non-existent HttpProvider import from utcp.shared.
  - Configured UtcpClientConfig with manual HttpCallTemplate entries for OpenLibrary.

<!-- End of auto-generated description by cubic. -->

